### PR TITLE
feat: add `preferGET` option

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -110,7 +110,7 @@ Example:
 
 ### preferGET
 
-An array of [origins](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin) to lets the rule connect to the origin's URL by `GET` instead of default `HEAD` request.
+An array of [origins](https://url.spec.whatwg.org/#origin) to lets the rule connect to the origin's URL by `GET` instead of default `HEAD` request.
 
 Although the rule will fall back to `GET` method when `HEAD` request is failed (status code is not between 200 and 300), in order to shorten time to run your test, you can use this option when you are sure that target origin always returns 5xx for `HEAD` request.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -62,7 +62,8 @@ The default options are:
     "no-dead-link": {
       "checkRelative": true,
       "baseURI": null,
-      "ignore": []
+      "ignore": [],
+      "preferGET": []
     }
   }
 }
@@ -103,6 +104,22 @@ Example:
 "no-dead-link": {
   "ignore": [
     "http://example.com/not-exist/index.html"
+  ]
+}
+```
+
+### preferGET
+
+An array of [origins](https://developer.mozilla.org/en-US/docs/Web/API/URL/origin) to lets the rule connect to the origin's URL by `GET` instead of default `HEAD` request.
+
+Although the rule will fall back to `GET` method when `HEAD` request is failed (status code is not between 200 and 300), in order to shorten time to run your test, you can use this option when you are sure that target origin always returns 5xx for `HEAD` request.
+
+Example:
+
+```json
+"no-dead-link": {
+  "preferGET": [
+    "http://example.com"
   ]
 }
 ```

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "repository": "textlint-rule/textlint-rule-no-dead-link",
   "dependencies": {
     "fs-extra": "^5.0.0",
+    "get-url-origin": "^1.0.1",
     "isomorphic-fetch": "^2.2.1",
     "textlint-rule-helper": "^2.0.0"
   },

--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -3,11 +3,13 @@ import fetch from 'isomorphic-fetch';
 import URL from 'url';
 import fs from 'fs-extra';
 import { isAbsolute } from 'path';
+import { getURLOrigin } from 'get-url-origin';
 
 const DEFAULT_OPTIONS = {
   checkRelative: true, // {boolean} `false` disables the checks for relative URIs
   baseURI: null, // {String|null} a base URI to resolve relative URIs.
   ignore: [], // {Array<String>} URIs to be skipped from availability checks.
+  preferGET: [], // {Array<String>} origins to prefer GET over HEAD.
 };
 
 // Adopted from http://stackoverflow.com/a/3809435/951517
@@ -84,6 +86,10 @@ async function isAliveURI(uri, method = 'HEAD') {
       };
     }
 
+    if (!res.ok && method === 'HEAD') {
+      return isAliveURI(uri, 'GET');
+    }
+
     return {
       ok: res.ok,
       message: `${res.status} ${res.statusText}`,
@@ -156,9 +162,14 @@ function reporter(context, options = {}) {
       uri = URL.resolve(base, uri);
     }
 
+    const method =
+      opts.preferGET.filter((origin) => getURLOrigin(uri) === origin).length > 0
+        ? 'GET'
+        : 'HEAD';
+
     const result = isLocal(uri)
       ? await isAliveLocalFile(uri)
-      : await isAliveURI(uri);
+      : await isAliveURI(uri, method);
     const { ok, redirected, redirectTo, message } = result;
 
     if (!ok) {

--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -163,7 +163,9 @@ function reporter(context, options = {}) {
     }
 
     const method =
-      opts.preferGET.filter((origin) => getURLOrigin(uri) === origin).length > 0
+      opts.preferGET.filter(
+        (origin) => getURLOrigin(uri) === getURLOrigin(origin),
+      ).length > 0
         ? 'GET'
         : 'HEAD';
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,2 +1,2 @@
 --require babel-core/register
---timeout 10000
+--timeout 20000

--- a/test/no-dead-link.js
+++ b/test/no-dead-link.js
@@ -10,6 +10,7 @@ tester.run('no-dead-link', rule, {
   valid: [
     'should be able to check a link in Markdown: [example](https://example.com/)',
     'should be able to check a URL in Markdown: https://example.com/',
+    'should success with retrying on error: [npm results for textlint](https://www.npmjs.com/search?q=textlint)',
     'should treat 200 OK as alive: https://httpstat.us/200',
     {
       text:
@@ -56,6 +57,13 @@ tester.run('no-dead-link', rule, {
     },
     {
       inputPath: path.join(__dirname, 'fixtures/a.md'),
+    },
+    {
+      text:
+        'should success with GET method: [npm results for textlint](https://www.npmjs.com/search?q=textlint)',
+      options: {
+        preferGET: ['https://www.npmjs.com'],
+      },
     },
   ],
   invalid: [

--- a/test/no-dead-link.js
+++ b/test/no-dead-link.js
@@ -65,6 +65,13 @@ tester.run('no-dead-link', rule, {
         preferGET: ['https://www.npmjs.com'],
       },
     },
+    {
+      text:
+        'should success with GET method whether the option is specific URL: [npm results for textlint](https://www.npmjs.com/search?q=textlint)',
+      options: {
+        preferGET: ['https://www.npmjs.com/search?q=textlint-rule'],
+      },
+    },
   ],
   invalid: [
     {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1523,6 +1523,10 @@ get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
+get-url-origin@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-url-origin/-/get-url-origin-1.0.1.tgz#edebfcc085433e84c6b32a5738b0996edfd5a7b9"
+
 getpass@^0.1.1:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.6.tgz#283ffd9fc1256840875311c1b60e8c40187110e6"


### PR DESCRIPTION
Add new option which enables user specify initial request method for each hosts. Closes #96.