### PR TITLE
Add ignore redirects

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -63,7 +63,8 @@ The default options are:
       "checkRelative": true,
       "baseURI": null,
       "ignore": [],
-      "preferGET": []
+      "preferGET": [],
+      "ignoreRedirects": false
     }
   }
 }
@@ -96,7 +97,7 @@ Examples:
 
 ### ignore
 
-An array of URIs or [glob](https://github.com/isaacs/node-glob "glob")s to be ignored.
+An array of URIs or [glob](https://github.com/isaacs/node-glob 'glob')s to be ignored.
 These list will be skipped from the availability checks.
 
 Example:
@@ -125,6 +126,11 @@ Example:
   ]
 }
 ```
+
+### ignoreRedirects
+
+This rule checks for redirects (3xx status codes) and consider's them an error by default.
+To ignore redirects during checks, set this value to `false`.
 
 ## Tests
 

--- a/src/no-dead-link.js
+++ b/src/no-dead-link.js
@@ -183,7 +183,7 @@ function reporter(context, options = {}) {
       const lintMessage = `${uri} is dead. (${message})`;
 
       report(node, new RuleError(lintMessage, { index }));
-    } else if (redirected) {
+    } else if (redirected && !opts.ignoreRedirects) {
       const lintMessage = `${uri} is redirected to ${redirectTo}. (${message})`;
       const fix = fixer.replaceTextRange(
         [index, index + uri.length],

--- a/test/no-dead-link.js
+++ b/test/no-dead-link.js
@@ -79,6 +79,13 @@ tester.run('no-dead-link', rule, {
         preferGET: ['https://www.npmjs.com/search?q=textlint-rule'],
       },
     },
+    {
+      text:
+        'should not treat https://httpstat.us/301 when `ignoreRedirects` is true',
+      options: {
+        ignoreRedirects: true,
+      },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Adds an `ignoreRedirects` option that when set to `true`, does not consider a redirect an error. 