### PR TITLE
feat(rule): add `dotInIgnore` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,15 @@ The primary target of this rule is Markdown documents, but it also works on plai
 
 ## Installation
 
-```
-$ npm install textlint-rule-no-dead-link
+```shell
+npm install textlint-rule-no-dead-link
 ```
 
 ## Usage
 
-```
-$ npm install textlint textlint-rule-no-dead-link
-$ textlint --rule textlint-rule-no-dead-link text-to-check.txt
+```shell
+npm install textlint textlint-rule-no-dead-link
+textlint --rule textlint-rule-no-dead-link text-to-check.txt
 ```
 
 ## Features
@@ -133,7 +133,7 @@ Example:
 This rule checks for redirects (3xx status codes) and consider's them an error by default.
 To ignore redirects during checks, set this value to `false`.
 
-<!-- Experimental 
+<!-- Experimental
 
 ### concurrency
 
@@ -170,7 +170,7 @@ Default: `10`
 ## CI Integration
 
 Probably, Link Checking take long times.
-We recommened to use cron job like GitHub Actions.
+We recommend to use cron job like GitHub Actions.
 
 ### textlint + [SARIF output](https://www.npmjs.com/package/@microsoft/eslint-formatter-sarif) + [code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning)
 
@@ -178,9 +178,9 @@ Preparing:
 
 ```shell
 # Install dependencies
-$ npm install --save-dev textlint @microsoft/eslint-formatter-sarif textlint-rule-no-dead-link
+npm install --save-dev textlint @microsoft/eslint-formatter-sarif textlint-rule-no-dead-link
 # Create .textlintrc
-$ npx textlint --init
+npx textlint --init
 ```
 
 Following actions check links and upload the status to [code scanning](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/about-code-scanning).
@@ -219,7 +219,7 @@ jobs:
 
 ## Tests
 
-```
+```shell
 npm test
 ```
 
@@ -233,4 +233,4 @@ npm test
 
 ## License
 
-MIT License (http://nodaguti.mit-license.org/)
+MIT License (<http://nodaguti.mit-license.org/>)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ The default options are:
       "checkRelative": true,
       "baseURI": null,
       "ignore": [],
-      "preferGET": [],
+      "dotInIgnore": false,
       "ignoreRedirects": false,
+      "preferGET": [],
       "retry": 3,
       "userAgent": "textlint-rule-no-dead-link/1.0",
       "maxRetryTime": 10,
@@ -111,6 +112,14 @@ Example:
   ]
 }
 ```
+
+### dotInIgnore
+
+This rule allows ignore patterns to match filenames starting with a period.
+For example, if the `ignore` option contains `"http://example.com/**"` and the `dotInIgnore` option is set to `true`, paths containing filenames that start with `.` (like `"http://example.com/.hidden/index.html"`) will be ignored.
+You can disable this behavior by setting `dotInIgnore` to `false`.
+
+_cf_, <https://github.com/isaacs/minimatch?tab=readme-ov-file#dot>
 
 ### preferGET
 

--- a/test/no-dead-link.ts
+++ b/test/no-dead-link.ts
@@ -27,7 +27,7 @@ tester.run("no-dead-link", rule, {
             ext: ".txt"
         },
         {
-            text: "should be able to check relative pathes when checkRelative is true: ![robot](index.html)",
+            text: "should be able to check relative paths when checkRelative is true: ![robot](index.html)",
             options: {
                 baseURI: "https://example.com/"
             }
@@ -42,6 +42,13 @@ tester.run("no-dead-link", rule, {
             text: 'should ignore URLs in the "ignore" option that glob formatted: https://example.com/404.html shouldn\'t be checked.',
             options: {
                 ignore: ["https://example.com/*"]
+            }
+        },
+        {
+            text: 'should ignore URLs containing . in their path in the "ignore" option that glob formatted if option is enabled: https://example.com/.hidden/404.html shouldn\'t be checked.',
+            options: {
+                ignore: ["https://example.com/**"],
+                dotInIgnore: true
             }
         },
         {
@@ -210,7 +217,7 @@ tester.run("no-dead-link", rule, {
         },
         {
             text: `Support Reference link[^1] in Markdown.
-             
+
 [^1] https://httpstat.us/404`,
             errors: [
                 {


### PR DESCRIPTION
This Pull Request addresses an issue where URIs containing filenames that start with a period (`.`) are not ignored, even when specified using a glob pattern in the `ignore` option. To resolve this, an option has been added to enable the dot option from the [minimatch](https://github.com/isaacs/minimatch?tab=readme-ov-file#dot).

Specifically, this option addresses cases to ignore URI like `https://github.com/textlint-rule/textlint-rule-no-dead-link/blob/master/.github/workflows/test.yml`.