### PR TITLE
feat: implement local test server to replace httpstat.us

### DIFF
--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -1,0 +1,126 @@
+import http from "http";
+import { URL } from "url";
+
+interface TestServerOptions {
+    port?: number;
+}
+
+interface TestServerResult {
+    url: string;
+    port: number;
+    close: () => Promise<void>;
+}
+
+export async function startTestServer(options: TestServerOptions = {}): Promise<TestServerResult> {
+    const port = options.port || 0; // Use 0 to let the OS assign an available port
+
+    const server = http.createServer((req, res) => {
+        const url = new URL(req.url || "/", `http://localhost:${port}`);
+        const pathname = url.pathname;
+
+        // Set CORS headers
+        res.setHeader("Access-Control-Allow-Origin", "*");
+        res.setHeader("Access-Control-Allow-Methods", "GET, HEAD, POST, OPTIONS");
+        res.setHeader("Access-Control-Allow-Headers", "Content-Type, User-Agent");
+
+        // Handle OPTIONS requests
+        if (req.method === "OPTIONS") {
+            res.writeHead(200);
+            res.end();
+            return;
+        }
+
+        // Handle different status codes based on path
+        switch (pathname) {
+            case "/200":
+                res.writeHead(200, { "Content-Type": "text/plain" });
+                res.end("OK");
+                break;
+
+            case "/301":
+                res.writeHead(301, {
+                    Location: `http://localhost:${port}/200`,
+                    "Content-Type": "text/plain"
+                });
+                res.end("Moved Permanently");
+                break;
+
+            case "/302":
+                res.writeHead(302, {
+                    Location: `http://localhost:${port}/200`,
+                    "Content-Type": "text/plain"
+                });
+                res.end("Found");
+                break;
+
+            case "/404":
+                res.writeHead(404, { "Content-Type": "text/plain" });
+                res.end("Not Found");
+                break;
+
+            case "/500":
+                res.writeHead(500, { "Content-Type": "text/plain" });
+                res.end("Internal Server Error");
+                break;
+
+            case "/301-external":
+                // Redirect to an external URL (for testing external redirects)
+                res.writeHead(301, {
+                    Location: "https://example.com/",
+                    "Content-Type": "text/plain"
+                });
+                res.end("Moved Permanently");
+                break;
+
+            case "/user-agent-required":
+                // Requires specific User-Agent header
+                if (req.headers["user-agent"] && req.headers["user-agent"].includes("Mozilla")) {
+                    res.writeHead(200, { "Content-Type": "text/plain" });
+                    res.end("OK - User-Agent accepted");
+                } else {
+                    res.writeHead(403, { "Content-Type": "text/plain" });
+                    res.end("Forbidden - User-Agent required");
+                }
+                break;
+
+            case "/timeout":
+                // Simulate a timeout by not responding
+                setTimeout(() => {
+                    res.writeHead(200, { "Content-Type": "text/plain" });
+                    res.end("Delayed response");
+                }, 10000); // 10 seconds delay
+                break;
+
+            default:
+                // Default to 200 OK for any other path
+                res.writeHead(200, { "Content-Type": "text/plain" });
+                res.end("Default OK response");
+                break;
+        }
+    });
+
+    return new Promise((resolve, reject) => {
+        server.listen(port, () => {
+            const actualPort = (server.address() as any).port;
+            const serverUrl = `http://localhost:${actualPort}`;
+            console.log(`Test server started on port ${actualPort}`);
+
+            const closeServer = () => {
+                return new Promise<void>((resolveClose) => {
+                    server.close(() => {
+                        console.log("Test server stopped");
+                        resolveClose();
+                    });
+                });
+            };
+
+            resolve({
+                url: serverUrl,
+                port: actualPort,
+                close: closeServer
+            });
+        });
+
+        server.on("error", reject);
+    });
+}


### PR DESCRIPTION
## Summary
- Implements a local test server to replace the external httpstat.us service that is no longer available
- Re-enables previously disabled redirect tests 
- Adds support for testing User-Agent requirements

## Changes
- Added `test/test-server.ts` with a Node.js HTTP server that simulates various response codes (200, 301, 302, 404, 500)
- Updated `test/no-dead-link.ts` to use the local test server on port 35481
- Re-enabled redirect tests that were previously disabled due to httpstat.us being down
- Added test cases for User-Agent requirement validation

## Test plan
- [x] All existing tests pass
- [x] Previously disabled redirect tests now work with local server
- [x] New User-Agent requirement tests added and passing
- [x] Server properly starts before tests and stops after tests complete

Closes #157

🤖 Generated with [Claude Code](https://claude.ai/code)