### PR TITLE
test: add local server tests for preferGET option

### DIFF
--- a/test/no-dead-link.ts
+++ b/test/no-dead-link.ts
@@ -95,19 +95,19 @@ tester.run("no-dead-link", rule, {
         {
             inputPath: path.join(__dirname, "fixtures/a.md")
         },
-        // SKIP: External service tests (npmjs.com)
-        // {
-        //     text: "should success with GET method: [npm results for textlint](https://www.npmjs.com/search?q=textlint)",
-        //     options: {
-        //         preferGET: ["https://www.npmjs.com"]
-        //     }
-        // },
-        // {
-        //     text: "should success with GET method whether the option is specific URL: [npm results for textlint](https://www.npmjs.com/search?q=textlint)",
-        //     options: {
-        //         preferGET: ["https://www.npmjs.com/search?q=textlint-rule"]
-        //     }
-        // },
+        // Test preferGET option with local server
+        {
+            text: `should success with GET method: [preferGET endpoint](${TEST_SERVER_URL}/preferGET)`,
+            options: {
+                preferGET: [TEST_SERVER_URL]
+            }
+        },
+        {
+            text: `should success with GET method when the option is specific URL: [preferGET endpoint](${TEST_SERVER_URL}/preferGET)`,
+            options: {
+                preferGET: [`${TEST_SERVER_URL}/preferGET`]
+            }
+        },
         // Test that redirect is not reported when ignoreRedirects is true
         {
             text: `should not report redirect when ignoreRedirects is true: ${TEST_SERVER_URL}/301`,

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -91,6 +91,23 @@ export async function startTestServer(options: TestServerOptions = {}): Promise<
                 }, 10000); // 10 seconds delay
                 break;
 
+            case "/preferGET":
+                // Endpoint that only works with GET method
+                // Used to test preferGET option
+                if (req.method === "HEAD") {
+                    // HEAD request returns 405 Method Not Allowed
+                    res.writeHead(405, { "Content-Type": "text/plain" });
+                    res.end();
+                } else if (req.method === "GET") {
+                    // GET request returns 200 OK
+                    res.writeHead(200, { "Content-Type": "text/html" });
+                    res.end("<html><body>This endpoint requires GET method</body></html>");
+                } else {
+                    res.writeHead(405, { "Content-Type": "text/plain" });
+                    res.end("Method Not Allowed");
+                }
+                break;
+
             default:
                 // Default to 200 OK for any other path
                 res.writeHead(200, { "Content-Type": "text/plain" });


### PR DESCRIPTION
## Summary

This PR enhances the test suite by adding local server tests for the `preferGET` option, eliminating the dependency on external services (npmjs.com) that were previously commented out. The changes ensure more reliable and maintainable tests by using a controlled local test server environment.

## Changes

### Test Server Enhancement
- Added `/preferGET` endpoint to the local test server that simulates a service requiring GET requests
  - Returns `405 Method Not Allowed` for HEAD requests
  - Returns `200 OK` for GET requests
  - Properly handles the preferGET option behavior

### Test Coverage
- Replaced commented-out external service tests with local server equivalents
- Added two test cases for the `preferGET` option:
  1. Tests with base URL in preferGET configuration
  2. Tests with specific URL path in preferGET configuration

## Motivation

The `preferGET` option allows textlint-rule-no-dead-link to use GET requests instead of HEAD requests for specific URLs. Some services (like npmjs.com search) don't support HEAD requests and return 405 errors. This option enables proper link validation for such services.

Previously, these tests relied on external services which could:
- Cause flaky tests due to network issues
- Fail if the external service changes behavior
- Slow down test execution

By using a local test server, we achieve:
- Deterministic test behavior
- Faster test execution
- No external dependencies
- Better test maintainability

## Test Plan

N/A - This PR only adds automated tests and doesn't change production code.

## Related Issues

This change supports better testing infrastructure and removes external dependencies from the test suite.