### PR TITLE
ci: improve workflow triggers to prevent duplicate runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   test:
     name: "Test on Node.js ${{ matrix.node-version }} ${{ matrix.os }}"


### PR DESCRIPTION
## Summary
- Improved GitHub Actions workflow configuration to prevent duplicate runs
- Configured push events to only trigger on master branch
- Pull request events continue to run for all branches

## Changes
- Modified `.github/workflows/test.yml` to use structured event configuration
- Push events now only trigger on `master` branch
- Pull request events remain unrestricted (run on all branches)

## Why this change?
When a pull request is created from a branch within the same repository, the workflow was running twice:
1. Once for the push event
2. Once for the pull_request event

This change ensures the workflow runs only once per PR by limiting push events to the master branch only.

## Test plan
- [x] Tests pass locally
- [x] YAML syntax is valid
- [ ] Workflow runs correctly on PR creation
- [ ] Workflow runs correctly on push to master

Fixes #162

🤖 Generated with [Claude Code](https://claude.ai/code)