### PR TITLE
fix: skip retry on successful HTTP responses

### DIFF
--- a/src/no-dead-link.ts
+++ b/src/no-dead-link.ts
@@ -232,7 +232,7 @@ const createCheckAliveURL = (ruleOptions: Options, resolvePath: (path: string, b
             }
 
             // try to fetch again if not reach max retry count
-            if (currentRetryCount < maxRetryCount) {
+            if (!res.ok && currentRetryCount < maxRetryCount) {
                 const retryAfter = res.headers.get("Retry-After");
                 // If the response has `Retry-After` header, prefer it
                 // e.g. `Retry-After: 60` and `maxRetryAfterTime: 90`, wait 60 seconds


### PR DESCRIPTION
fixes #176 
Add `!res.ok` guard to the second retry block in `isAliveURI`. Without this, a 200 OK response still triggers up to `retry` (default: 3) unnecessary GET requests per link.