### PR TITLE
fix: retry GET requests on network errors

### DIFF
--- a/src/no-dead-link.ts
+++ b/src/no-dead-link.ts
@@ -265,6 +265,11 @@ const createCheckAliveURL = (ruleOptions: Options, resolvePath: (path: string, b
                 return isAliveURI(uri, "GET", maxRetryCount, currentRetryCount + 1);
             }
 
+            // Retry on network errors (e.g. ECONNRESET, timeout) for GET requests as well
+            if (method === "GET" && currentRetryCount < maxRetryCount) {
+                return isAliveURI(uri, "GET", maxRetryCount, currentRetryCount + 1);
+            }
+
             return {
                 ok: false,
                 message: ex.message


### PR DESCRIPTION
fixes: #178 
Network errors (e.g. ECONNRESET, timeout) during GET requests were not retried, causing immediate false-positive dead link reports regardless of the `retry` option value.