### PR TITLE
fix: "Failed to parse URL" false positive

### DIFF
--- a/src/no-dead-link.ts
+++ b/src/no-dead-link.ts
@@ -151,10 +151,9 @@ type AliveFunctionReturn = {
 /**
  * Create isAliveURI function with ruleOptions
  * @param {object} ruleOptions
- * @param {function} resolvePath
  * @returns {isAliveURI}
  */
-const createCheckAliveURL = (ruleOptions: Options, resolvePath: (path: string, base: string) => string | undefined) => {
+const createCheckAliveURL = (ruleOptions: Options) => {
     // Create fetch function for this rule
     const fetchWithDefaults = createFetchWithRuleDefaults(ruleOptions);
     /**
@@ -205,12 +204,7 @@ const createCheckAliveURL = (ruleOptions: Options, resolvePath: (path: string, b
                     return errorResult;
                 }
 
-                const base = URL.parse(uri)?.origin;
-                if (!base) {
-                    return errorResult;
-                }
-
-                const redirectedUrl = resolvePath(location, base);
+                const redirectedUrl = URL.parse(location, uri)?.href;
                 if (!redirectedUrl) {
                     return errorResult;
                 }
@@ -325,7 +319,7 @@ const reporter: TextlintRuleReporter<Options> = (context, options) => {
         const memoOptionsKey = JSON.stringify(ruleOptions);
         const func = memorizedIsAliveURIByOptions.get(memoOptionsKey);
         if (!func) {
-            const isAliveURI = createCheckAliveURL(ruleOptions, resolvePath);
+            const isAliveURI = createCheckAliveURL(ruleOptions);
             const func = pMemoize(isAliveURI, {
                 maxAge: ruleOptions.linkMaxAge
             });

--- a/test/no-dead-link.ts
+++ b/test/no-dead-link.ts
@@ -185,6 +185,16 @@ tester.run("no-dead-link", rule, {
             ]
         },
         {
+            text: `should treat 301 [link](${TEST_SERVER_URL}/301-root-relative)`,
+            output: `should treat 301 [link](${TEST_SERVER_URL}/200)`,
+            errors: [
+                {
+                    message: `${TEST_SERVER_URL}/301-root-relative is redirected to ${TEST_SERVER_URL}/200. (301 Moved Permanently)`,
+                    range: [24, 24 + TEST_SERVER_URL.length + 18] // /301-root-relative = 18 chars
+                }
+            ]
+        },
+        {
             text: `should treat 302 [link](${TEST_SERVER_URL}/302)`,
             output: `should treat 302 [link](${TEST_SERVER_URL}/200)`,
             errors: [

--- a/test/test-server.ts
+++ b/test/test-server.ts
@@ -81,6 +81,15 @@ export async function startTestServer(options: TestServerOptions = {}): Promise<
                 res.end("Moved Permanently");
                 break;
 
+            case "/301-root-relative":
+                // Redirect to a root-relative URL
+                res.writeHead(301, {
+                    Location: `/200`,
+                    "Content-Type": "text/plain"
+                });
+                res.end("Moved Permanently");
+                break;
+
             case "/user-agent-required":
                 // Requires specific User-Agent header
                 if (req.headers["user-agent"] && req.headers["user-agent"].includes("Mozilla")) {


### PR DESCRIPTION
fix #181 

I added the test case to address this issue, and the tests with master branch failed due to `Failed to parse URL`.

```
  1) no-dead-link
       should treat 301 [link](http://localhost:35481/301-root-relative):

      AssertionError [ERR_ASSERTION]: "message should be "http://localhost:35481/301-root-relative is redirected to http://localhost:35481/200. (301 Moved Permanently)"
+ actual - expected

+ 'http://localhost:35481/301-root-relative is dead. (Failed to parse URL from /200)'
- 'http://localhost:35481/301-root-relative is redirected to http://localhost:35481/200. (301 Moved Permanently)'

      + expected - actual

      -http://localhost:35481/301-root-relative is dead. (Failed to parse URL from /200)
      +http://localhost:35481/301-root-relative is redirected to http://localhost:35481/200. (301 Moved Permanently)
      
      at /workspaces/textlint-rule-no-dead-link/node_modules/.pnpm/textlint-tester@15.2.1/node_modules/textlint-tester/src/test-util.ts:144:24
      at Array.forEach (<anonymous>)
      at /workspaces/textlint-rule-no-dead-link/node_modules/.pnpm/textlint-tester@15.2.1/node_modules/textlint-tester/src/test-util.ts:114:16
      at processTicksAndRejections (node:internal/process/task_queues:104:5)

  2) no-dead-link
       Fixer: should treat 301 [link](http://localhost:35481/301-root-relative):

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+ actual - expected

+ 'should treat 301 [link](http://localhost:35481/301-root-relative)'
- 'should treat 301 [link](http://localhost:35481/200)'

      + expected - actual

      -should treat 301 [link](http://localhost:35481/301-root-relative)
      +should treat 301 [link](http://localhost:35481/200)
      
      at /workspaces/textlint-rule-no-dead-link/node_modules/.pnpm/textlint-tester@15.2.1/node_modules/textlint-tester/src/textlint-tester.ts:378:28
```

 Use `URL.parse` instead of `resolvePath`.